### PR TITLE
66 api tools has date info

### DIFF
--- a/app/api/tools/[id]/route.ts
+++ b/app/api/tools/[id]/route.ts
@@ -13,7 +13,6 @@ export async function GET(
         images: true,
         Transaction: {
           select: {
-            status: true,
             startDate: true,
             endDate: true
           },

--- a/app/api/tools/[id]/route.ts
+++ b/app/api/tools/[id]/route.ts
@@ -13,6 +13,7 @@ export async function GET(
         images: true,
         Transaction: {
           select: {
+            status: true,
             startDate: true,
             endDate: true
           },

--- a/app/api/tools/[id]/route.ts
+++ b/app/api/tools/[id]/route.ts
@@ -13,12 +13,33 @@ export async function GET(
         images: true,
         Transaction: {
           select: {
+            status: true,
             startDate: true,
             endDate: true
+          },
+          where: {
+            NOT: {
+              status: 'COMPLETED'
+            }
           }
         }
       }
     });
+
+    const hasTransactions = tool?.Transaction?.length ?? 0 > 0;
+
+    if (!hasTransactions) {
+      const toolWithAvailability = { ...tool, available: true };
+      return NextResponse.json(toolWithAvailability);
+    }
+
+    const activeTransactionExists = tool?.Transaction.some(
+      (transaction) => transaction.status !== 'ACTIVE'
+    );
+    const toolWithAvailability = {
+      ...tool,
+      available: activeTransactionExists
+    };
 
     return NextResponse.json(tool);
   } catch (error) {

--- a/app/api/tools/[id]/route.ts
+++ b/app/api/tools/[id]/route.ts
@@ -9,7 +9,15 @@ export async function GET(
     const tool = await prisma?.item.findUnique({
       where: {
         id: params.id,
-      },
+      }, include: {
+        images: true,
+        Transaction: {
+          select: {
+            startDate: true,
+            endDate: true
+          }
+        }
+      }
     });
 
     return NextResponse.json(tool);

--- a/app/api/tools/route.ts
+++ b/app/api/tools/route.ts
@@ -8,13 +8,32 @@ export async function GET(req: NextRequest) {
       images: true,
       Transaction: {
         select: {
+          status: true,
           startDate: true,
           endDate: true
+        },
+        where: {
+          NOT: {
+            status: 'COMPLETED'
+          }
         }
       }
     }
-   });
-  return NextResponse.json(tools);
+  });
+
+  const toolsWithAvailability = tools.map(tool => {
+    const hasTransactions = tool.Transaction.length > 0;
+
+    if (!hasTransactions) {
+      return { ...tool, available: true };
+    }
+    const activeTransactionExists = hasTransactions && tool.Transaction.some(
+      transaction => transaction.status !== 'ACTIVE'
+    );
+    return { ...tool, available: activeTransactionExists };
+  });
+
+  return NextResponse.json(toolsWithAvailability);
 }
 
 export async function POST(req: NextRequest) {

--- a/app/api/tools/route.ts
+++ b/app/api/tools/route.ts
@@ -8,7 +8,6 @@ export async function GET(req: NextRequest) {
       images: true,
       Transaction: {
         select: {
-          status: true,
           startDate: true,
           endDate: true
         },

--- a/app/api/tools/route.ts
+++ b/app/api/tools/route.ts
@@ -5,7 +5,13 @@ import { Item } from "@/types/schemaTypes";
 export async function GET(req: NextRequest) {
   const tools = await prisma?.item.findMany({ 
     include: {
-      images: true
+      images: true,
+      Transaction: {
+        select: {
+          startDate: true,
+          endDate: true
+        }
+      }
     }
    });
   return NextResponse.json(tools);

--- a/app/api/tools/route.ts
+++ b/app/api/tools/route.ts
@@ -8,6 +8,7 @@ export async function GET(req: NextRequest) {
       images: true,
       Transaction: {
         select: {
+          status: true,
           startDate: true,
           endDate: true
         },


### PR DESCRIPTION
Haven't seen this in action with many transactions on a single item - 

Tool info - Added the following
 - Array of start/end date objects inside of Transaction (Date Picker's info)
 - available: true/false (green/red dot property)