### PR TITLE
route for List A Tool in hamburger menu

### DIFF
--- a/components/NavBar/navbar.tsx
+++ b/components/NavBar/navbar.tsx
@@ -101,7 +101,7 @@ const NavBar: React.FC = () => {
               <Link href='/profile'>My profile</Link>
             </li>
             <li>
-              <Link href='/list'>List a tool</Link>
+              <Link href='/profile/listings/newListing'>List a tool</Link>
             </li>
             <li>
               <Link href='/about'>About</Link>


### PR DESCRIPTION
User can now click on List A Tool from hamburger menu and it will direct them to the list a tool form.